### PR TITLE
Remove -type-in-type requirement.

### DIFF
--- a/code/_CoqProject
+++ b/code/_CoqProject
@@ -2,7 +2,6 @@ COQC = coqc
 COQDEP = coqdep
 -R . "sem"
 
--arg "-type-in-type"
 -arg "-w -notation-overridden"
 
 prelude/imports.v

--- a/code/examples/groups.v
+++ b/code/examples/groups.v
@@ -16,7 +16,7 @@ Definition group_operations
   := (I * I) + I + C unitset.
 
 (** Labels of group axioms *)
-Inductive group_ax : UU :=
+Inductive group_ax :=
 | assoc : group_ax
 | unit_l : group_ax
 | unit_r : group_ax

--- a/code/examples/integers.v
+++ b/code/examples/integers.v
@@ -22,7 +22,7 @@ Definition Z_operations
   := I (* suc *) + I (* pred *) + C unitset (* zero *).
 
 (** Labels of group axioms *)
-Inductive Z_ax : UU :=
+Inductive Z_ax :=
 | PS : Z_ax
 | SP : Z_ax.
 

--- a/code/examples/join_semilattice.v
+++ b/code/examples/join_semilattice.v
@@ -23,7 +23,7 @@ Definition semilattice_operations
      + C unitset (* empty *).
 
 (** Labels of group axioms *)
-Inductive semilattice_ax : UU :=
+Inductive semilattice_ax :=
 | nl : semilattice_ax
 | idem : semilattice_ax
 | com : semilattice_ax

--- a/code/examples/monoids.v
+++ b/code/examples/monoids.v
@@ -22,7 +22,7 @@ Definition monoid_operations
   := (I * I) + C unitset.
 
 (** Labels of monoid axioms *)
-Inductive monoid_ax : UU :=
+Inductive monoid_ax :=
 | assoc : monoid_ax
 | unit_l : monoid_ax
 | unit_r : monoid_ax.

--- a/code/examples/polynomials.v
+++ b/code/examples/polynomials.v
@@ -26,7 +26,7 @@ Section PolynomialRing.
     := C (alg_carrier R) + C A + ring_operations.
 
   (** Labels of polynomial axioms *)
-  Inductive polynomial_ax_help : UU :=
+  Inductive polynomial_ax_help :=
   | R_plus : polynomial_ax_help
   | R_times : polynomial_ax_help
   | R_one : polynomial_ax_help.

--- a/code/examples/rings.v
+++ b/code/examples/rings.v
@@ -20,7 +20,7 @@ Definition ring_operations
      + C unitset (* one *).
 
 (** Labels of group axioms *)
-Inductive ring_ax : UU :=
+Inductive ring_ax :=
 | p_assoc : ring_ax
 | p_unit : ring_ax
 | p_inv : ring_ax


### PR DESCRIPTION
Undoes part of a recent commit in order to not rely on -type-in-type.

Using `UU` is apparently problematic when not having `-type-in-type`. This removes `: UU` and also `-type-in-type`.