### PR TITLE
Rename `carrier_eq` to `carrier_eqrel`

### DIFF
--- a/code/algebras/setoid_algebra.v
+++ b/code/algebras/setoid_algebra.v
@@ -21,7 +21,7 @@ Definition poly_eq_rel
 Proof.
   induction P as [T | | P₁ IHP₁ P₂ IHP₂ | P₁ IHP₁ P₂ IHP₂].
   - exact (path_rel T).
-  - exact (carrier_eq X).
+  - exact (carrier_eqrel X).
   - exact (sum_rel IHP₁ IHP₂).
   - exact (prod_rel IHP₁ IHP₂).
 Defined.
@@ -223,7 +223,7 @@ Projections of algebras
 Section AlgebraProjections.
   Context {Σ : hit_signature}.
   Variable (X : setoid_algebra Σ).
-  
+
   Definition alg_to_prealg
     : setoid_prealgebras (point_arg Σ)
     := pr1 X.
@@ -275,7 +275,7 @@ Proof.
   - exact X.
   - exact c.
 Defined.
-           
+
 Definition make_algebra
            {Σ : hit_signature}
            (X : setoid)

--- a/code/existence/algebra_adjunction.v
+++ b/code/existence/algebra_adjunction.v
@@ -360,7 +360,7 @@ Proof.
   intro X.
   induction P as [T | | P₁ IHP₁ P₂ IHP₂ | P₁ IHP₁ P₂ IHP₂].
   - exact (quotient_counit T).
-  - exact (idfun (setquot (carrier_eq X))).
+  - exact (idfun (setquot (carrier_eqrel X))).
   - exact ((quotient_sum _ _) · coprod_maps BinCoproductsHSET IHP₁ IHP₂).
   - exact ((quotient_prod _ _) · prod_maps BinProductsHSET IHP₁ IHP₂).
 Defined.
@@ -396,7 +396,7 @@ Proof.
     + intros x.
       apply dirprod_paths.
       * exact (eqtohomot IHP₁ (setquotpr _ (pr1 x))).
-      * exact (eqtohomot IHP₂ (setquotpr _ (pr2 x))).      
+      * exact (eqtohomot IHP₂ (setquotpr _ (pr2 x))).
 Qed.
 
 Definition quotient_commute
@@ -429,7 +429,7 @@ Definition quotient_commute_is_inverse
 Proof.
   induction P as [T | | P₁ IHP₁ P₂ IHP₂ | P₁ IHP₁ P₂ IHP₂].
   - exact (quotient_counit_is_inverse T).
-  - exact (@is_inverse_in_precat_identity HSET (setquotinset (carrier_eq X))).
+  - exact (@is_inverse_in_precat_identity HSET (setquotinset (carrier_eqrel X))).
   - exact (is_inverse_in_precat_comp
              (quotient_sum_are_inverses (⟨ P₁ ⟩ X) (⟨ P₂ ⟩ X))
              (coprod_maps_inverse BinCoproductsHSET IHP₁ IHP₂)).
@@ -477,7 +477,7 @@ Definition quotient_prealgebras_unit_help_point
            (P : poly_code)
            (X : setoid_cat)
            (x : pr1 (⟨ P ⟩ X))
-  : setquotpr (carrier_eq (⟨ P ⟩ X)) x
+  : setquotpr (carrier_eqrel (⟨ P ⟩ X)) x
     =
     quotient_commute_inv_comp
       P X

--- a/code/setoids/base.v
+++ b/code/setoids/base.v
@@ -38,19 +38,19 @@ Definition make_setoid
 
 Coercion carrier (X : setoid) : hSet := pr1 X.
 
-Definition carrier_eq
+Definition carrier_eqrel
            (X : setoid)
   : eqrel X
   := pr2 X.
 
-Notation "x ≡ y" := (carrier_eq _ x y) (at level 70).
+Notation "x ≡ y" := (carrier_eqrel _ x y) (at level 70).
 
 Definition isaprop_setoid_eq
            {X : setoid}
            (x y : X)
   : isaprop (x ≡ y).
 Proof.
-  apply (pr1 (carrier_eq X)).
+  apply (pr1 (carrier_eqrel X)).
 Defined.
 
 Definition setoid_path
@@ -104,7 +104,7 @@ Definition setoid_morphism_eq
   : f = g.
 Proof.
   use subtypePath.
-  - intro.    
+  - intro.
     do 3 (apply impred ; intro).
     apply isaprop_setoid_eq.
   - apply funextsec.

--- a/code/setoids/setoid_category.v
+++ b/code/setoids/setoid_category.v
@@ -13,7 +13,7 @@ Open Scope cat.
 Definition setoid_cat_ob_mor
   : precategory_ob_mor.
 Proof.
-  use make_precategory_ob_mor. 
+  use make_precategory_ob_mor.
   - exact setoid.
   - exact setoid_morphism.
 Defined.
@@ -105,7 +105,7 @@ Defined.
 
 Definition sum_setoid (X Y : setoid_cat)
   : setoid_cat
-  := make_setoid (sum_rel (carrier_eq X) (carrier_eq Y)).
+  := make_setoid (sum_rel (carrier_eqrel X) (carrier_eqrel Y)).
 
 Definition setoid_inl
            (X₁ X₂ : setoid_cat)
@@ -193,7 +193,7 @@ Defined.
 
 Definition prod_setoid (X Y : setoid_cat)
   : setoid_cat
-  := make_setoid (prod_rel (carrier_eq X) (carrier_eq Y)).
+  := make_setoid (prod_rel (carrier_eqrel X) (carrier_eqrel Y)).
 
 Definition setoid_pr1
            (X₁ X₂ : setoid_cat)
@@ -391,7 +391,7 @@ Proof.
     + exact f.
     + exact (λ x y p, maponpaths f p).
 Defined.
-      
+
 Definition path_setoid : SET ⟶ setoid_cat.
 Proof.
   use make_functor.
@@ -412,7 +412,7 @@ Definition quotient_setoid_ob
 Proof.
   use setquotinset.
   - exact X.
-  - exact (carrier_eq X).
+  - exact (carrier_eqrel X).
 Defined.
 
 Definition quotient_setoid_mor
@@ -483,7 +483,7 @@ Defined.
 
 Definition quotient_counit_is_inverse
            (X : SET)
-  : is_inverse_in_precat (quotient_counit X) (setquotpr (carrier_eq (path_setoid X))).
+  : is_inverse_in_precat (quotient_counit X) (setquotpr (carrier_eqrel (path_setoid X))).
 Proof.
   split.
   - use funextsec.


### PR DESCRIPTION
to prevent a nameclash with an added equality lemma for carriers